### PR TITLE
Eliminate unnecessary seconds/hours conversion throughout codebase

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -107,7 +107,7 @@ where
 pub struct UpdateWorkHourRequest {
     pub date: String,
     pub description: String,
-    pub duration_seconds: f64,
+    pub duration_hours: f64,
 }
 
 #[derive(Debug, Serialize, Type)]
@@ -115,7 +115,7 @@ pub struct WorkHourResponse {
     pub id: String,
     pub date: String,
     pub description: String,
-    pub duration_seconds: f64,
+    pub duration_hours: f64,
 }
 
 // Teable API models
@@ -167,8 +167,8 @@ pub struct WorkHour {
     pub date: Option<String>,
     #[serde(rename = "Tätigkeit")]
     pub description: Option<String>,
-    #[serde(rename = "Stunden")] // This field stores seconds as a floating point number
-    pub duration_seconds: Option<f64>,
+    #[serde(rename = "Stunden")] // This field stores hours as a floating point number
+    pub duration_hours: Option<f64>,
 }
 
 impl WorkHour {

--- a/tsv-tennis-app/src/services/backendService.ts
+++ b/tsv-tennis-app/src/services/backendService.ts
@@ -144,20 +144,6 @@ class BackendService {
     }
   }
 
-  // Work hours methods
-  async getArbeitsstunden(): Promise<WorkHourResponse[] | ApiError> {
-    try {
-      const response = await this.api.get<WorkHourResponse[]>('/arbeitsstunden');
-      return response.data;
-    } catch (error: any) {
-      console.error('Error fetching work hours:', error);
-      return {
-        success: false,
-        message: error.response?.data?.message || 'Arbeitsstunden konnten nicht geladen werden'
-      };
-    }
-  }
-
   async createArbeitsstunden(data: CreateWorkHourRequest): Promise<ApiResponse | ApiError> {
     try {
       const response = await this.api.post<ApiResponse>('/arbeitsstunden', data);


### PR DESCRIPTION
Work directly with hours from Teable API to frontend instead of converting hours to seconds and back to hours unnecessarily.

Key changes:
- models.rs: Update WorkHour.duration_seconds → duration_hours fields
- teable.rs: Remove * 3600.0 and / 3600.0 conversions in API calls
- main.rs: Remove seconds_to_hours usage, work with hours directly
- utils.rs: Remove seconds_to_hours function, simplify time handling
- backendService.ts: Remove unused getArbeitsstunden method
- Fix test to use correct endpoint and expect object response

This simplifies the codebase by eliminating redundant time conversions since Teable API stores hours natively.